### PR TITLE
📝 Button 공통 컴포넌트 完

### DIFF
--- a/client/src/components/Button/Button.tsx
+++ b/client/src/components/Button/Button.tsx
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import { ButtonType } from "./type";
+
+const ButtonWrapper = styled.div`
+	width: fit-content;
+`
+const ButtonStyle = styled.button<ButtonType>`
+	width: 100%;
+	border: none;
+	border-radius: 0.5rem;
+	background-color: ${(props) => (props.type === 'variant' ? '#f20000' : '#232323')};
+	color: #FFFFFF;
+	padding: 0.7rem 1.3rem;
+
+	width: ${(props) => (props.width ? props.width : 'fit-content')};
+
+	&:hover {
+		background-color: ${(props) => (props.type === 'variant' ? '#c20000' : '#f20000')};
+    }
+`
+
+const Button = ( { value, type, width } : ButtonType ) => {
+	return (
+		<ButtonWrapper>
+		<ButtonStyle width={width} type={type}>{value}</ButtonStyle>
+		</ButtonWrapper>
+	)
+}
+
+export default Button;

--- a/client/src/components/Button/type.ts
+++ b/client/src/components/Button/type.ts
@@ -1,0 +1,5 @@
+export interface ButtonType {
+	value?: string;
+	type?: string ;
+	width?: string
+}


### PR DESCRIPTION
공통 컴포넌트 중 버튼 작성 완료 했습니다. 

### props
- 버튼에 적힐 문자인 `value`
- 버튼의 가로 길이 `width` 
- 버튼의 기본 색상 설정인 `type`
  -  `type` props의 경우, 아무 값도 안 주면 기본이 차콜(#232323) hover시 레드(#F20000)
  -  값으로 'variant' 를 주면 기본이 레드(#F20000) hover시 어두운 레드(#C20000)입니다.  
